### PR TITLE
Fix for application:start(epcap)

### DIFF
--- a/ebin/epcap.app
+++ b/ebin/epcap.app
@@ -12,6 +12,5 @@
                   kernel,
                   stdlib
                  ]},
-  {mod, {epcap_app, []}},
   {env, []}
  ]}.


### PR DESCRIPTION
./ebin/epcap.app has a reference to {mod, epcap_app} which doesn't actually exist (nor does it need to, since epcap acts as a library).  However, if you try to start epcap as an application (which happens automatically if you include epcap as part of a release package, it will blow up with an {undef, epcap_app}.  This patch fixes the problem.  Please consider for merging
