### PR TITLE
Update deps config to explicitly use branch master

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -10,5 +10,5 @@
 ]}.
 
 {deps, [
-    {pkt, ".*", {git, "https://github.com/msantos/pkt.git", "master"}}
+    {pkt, ".*", {git, "https://github.com/msantos/pkt.git", {branch, "master"}}}
 ]}.


### PR DESCRIPTION
Update the dep configuration of pkt to explicitly use the master *branch*.
This is the de-facto convention (as implemented in rebar3 as well).
See: https://github.com/rebar/rebar/issues/507