### PR TITLE
Add immediate mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ To compile the examples:
                             {monitor, boolean()} | {cpu_affinity, string()} | {cluster_id, non_neg_integer()}} |
                             {inject, boolean()} | {snaplen, non_neg_integer} | {buffer, non_neg_integer()} |
                             {time_unit, microsecond | timestamp} | {direction, in | out | inout} |
-                            {immediate, boolean()}, {env, string()}
+                            {timeout, pos_integer()}, {immediate, boolean()},
+                            {env, string()}
 
         Packets are delivered as messages:
 
@@ -71,7 +72,10 @@ To compile the examples:
         option. The buffer size must be larger than the snapshot
         length (default: 65535) plus some overhead for the pcap data
         structures. Using some multiple of the snapshot length is
-        suggested.
+        suggested. The timeout used when appending subsequent packets
+        to the buffer can be controlled by the 'timeout' option on some
+        platforms (value in msecs), given that the 'immediate' option is
+        set to 'false' explicitly.
 
     epcap:send(Ref, Packet) -> ok
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To compile the examples:
                             {monitor, boolean()} | {cpu_affinity, string()} | {cluster_id, non_neg_integer()}} |
                             {inject, boolean()} | {snaplen, non_neg_integer} | {buffer, non_neg_integer()} |
                             {time_unit, microsecond | timestamp} | {direction, in | out | inout} |
-                            {env, string()}
+                            {immediate, boolean()}, {env, string()}
 
         Packets are delivered as messages:
 

--- a/c_src/epcap.c
+++ b/c_src/epcap.c
@@ -86,8 +86,9 @@ int main(int argc, char *argv[]) {
 
   ep->snaplen = SNAPLEN;
   ep->timeout = TIMEOUT;
+  ep->opt |= EPCAP_OPT_IMMEDIATE;
 
-  while ((ch = getopt(argc, argv, "b:d:e:f:g:hi:MPs:T:t:u:Q:vX")) != -1) {
+  while ((ch = getopt(argc, argv, "b:d:e:f:g:hi:MPs:T:t:I:u:Q:vX")) != -1) {
     switch (ch) {
     case 'b':
       ep->bufsz = strtonum(optarg, INT32_MIN, INT32_MAX, NULL);
@@ -163,6 +164,14 @@ int main(int argc, char *argv[]) {
       break;
     case 't':
       ep->timeout = strtonum(optarg, INT32_MIN, INT32_MAX, NULL);
+      if (errno)
+        exit(errno);
+      break;
+    case 'I':
+      if (strtonum(optarg, 0, 1, NULL))
+        ep->opt |= EPCAP_OPT_IMMEDIATE;
+      else
+        ep->opt &= ~EPCAP_OPT_IMMEDIATE;
       if (errno)
         exit(errno);
       break;
@@ -403,6 +412,7 @@ static int epcap_open(EPCAP_STATE *ep) {
 
     (void)pcap_set_snaplen(ep->p, ep->snaplen);
     (void)pcap_set_promisc(ep->p, ep->opt & EPCAP_OPT_PROMISC);
+    (void)pcap_set_immediate_mode(ep->p, ep->opt & EPCAP_OPT_IMMEDIATE);
     (void)pcap_set_timeout(ep->p, ep->timeout);
 
     if (ep->bufsz > 0)
@@ -633,6 +643,7 @@ static void usage(EPCAP_STATE *ep) {
 #endif
       "              -s <length>      packet capture length\n"
       "              -t <millisecond> capture timeout\n"
+      "              -I               enable immediate mode\n"
       "              -e <key>=<val>   set an environment variable\n"
       "              -v               verbose mode\n"
       "              -X               enable sending packets\n"

--- a/c_src/epcap.h
+++ b/c_src/epcap.h
@@ -85,6 +85,7 @@ enum {
   EPCAP_OPT_RUNASUSER = 1 << 1, /* setuid: drop privs to calling user */
   EPCAP_OPT_RFMON = 1 << 2,     /* enable monitor mode */
   EPCAP_OPT_INJECT = 1 << 3,    /* enable packet injection */
+  EPCAP_OPT_IMMEDIATE = 1 << 4, /* enable capture immediate mode */
 };
 
 typedef struct {

--- a/src/epcap.erl
+++ b/src/epcap.erl
@@ -186,7 +186,7 @@ handle_info(Info,
 %%--------------------------------------------------------------------
 -type arg_num() :: string() | non_neg_integer().
 
--type options() :: [inject | monitor | promiscuous | verbose |
+-type options() :: [inject | monitor | promiscuous | verbose | immediate |
                     {buffer, arg_num()} | {chroot, string()} | {cluster_id, arg_num()} |
                     {direction, in | out | inout} | {env, string()} | {exec, string()} |
                     {file, string()} | {filter, string()} | {group, string()} |
@@ -231,6 +231,8 @@ optarg(promiscuous) -> switch("P");
 optarg({snaplen, Arg}) -> switch("s", maybe_string(Arg));
 optarg({time_unit, Arg}) -> switch("T", time_unit(Arg));
 optarg({timeout, Arg}) -> switch("t", maybe_string(Arg));
+optarg(immediate) -> switch("I", "1");
+optarg({immediate, false}) -> switch("I", "0");
 optarg({user, Arg}) -> switch("u", Arg);
 optarg(verbose) -> switch("v");
 optarg({verbose, 0}) -> "";

--- a/test/epcap_SUITE.erl
+++ b/test/epcap_SUITE.erl
@@ -134,12 +134,13 @@ getopts(_Config) ->
     [Sudo, "-n", Progname, "-b", "1024", "-d", "/tmp/", "-e",
      "PCAP_PF_RING_CLUSTER_ID=0", "-g", "nobody", "-i", "eth0", "-M", "-P", "-s",
      "256", "-T", "1", "-u", "nobody", "-v", "-vvv", "-X", "-Q", "inout", "-t", "0",
-     "-e", "FOO=bar", "tcp and port 80"] =
+     "-I", "1", "-I", "0", "-e", "FOO=bar", "tcp and port 80"] =
         epcap:getopts([{buffer, 1024}, {chroot, "/tmp/"}, {cluster_id, 0},
                        {group, "nobody"}, {interface, "eth0"}, monitor, promiscuous, {snaplen, 256},
                        {time_unit, microsecond}, {time_out, 60}, {user, "nobody"}, verbose,
                        {verbose, 3}, {verbose, 0}, inject, {direction, inout},
                        {filter, "tcp and port 80"}, {timeout, 0}, {exec, "sudo -n"},
+                       immediate, {immediate, false},
                        {env, "FOO=bar"}]),
     "sudo" = filename:basename(Sudo),
     "epcap" = filename:basename(Progname),


### PR DESCRIPTION
Currently the test suite does not run successfully on Linux 5.4.0 / libpcap 1.9.1 due to timeouts.

There is also no way to force the immediate mode in a portable way (the closest would be {timeout, 1}).

Add an option 'immediate' ('-I' in epcap's CLI) to explicitly set libpcap's immediate mode and use it in the test suite instead of relying on the default timeout settings.