### PR TITLE
Combine 'timeout' and 'immediate' options

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To compile the examples:
                             {monitor, boolean()} | {cpu_affinity, string()} | {cluster_id, non_neg_integer()}} |
                             {inject, boolean()} | {snaplen, non_neg_integer} | {buffer, non_neg_integer()} |
                             {time_unit, microsecond | timestamp} | {direction, in | out | inout} |
-                            {timeout, pos_integer()}, {immediate, boolean()},
+                            {timeout, pos_integer() | infinity | immediate},
                             {env, string()}
 
         Packets are delivered as messages:
@@ -74,8 +74,10 @@ To compile the examples:
         structures. Using some multiple of the snapshot length is
         suggested. The timeout used when appending subsequent packets
         to the buffer can be controlled by the 'timeout' option on some
-        platforms (value in msecs), given that the 'immediate' option is
-        set to 'false' explicitly.
+        platforms (value in msecs), the special values 'infinity' (wait
+        until the pcap buffer is filled) and 'immediate' (do not wait
+        after the first packet). The value 0 is equivalent to
+        'immediate' which differs from the definition given in pcap(3PCAP).
 
     epcap:send(Ref, Packet) -> ok
 

--- a/c_src/epcap.c
+++ b/c_src/epcap.c
@@ -88,7 +88,7 @@ int main(int argc, char *argv[]) {
   ep->timeout = TIMEOUT;
   ep->opt |= EPCAP_OPT_IMMEDIATE;
 
-  while ((ch = getopt(argc, argv, "b:d:e:f:g:hi:MPs:T:t:I:u:Q:vX")) != -1) {
+  while ((ch = getopt(argc, argv, "b:d:e:f:g:hi:MPs:T:t:u:Q:vX")) != -1) {
     switch (ch) {
     case 'b':
       ep->bufsz = strtonum(optarg, INT32_MIN, INT32_MAX, NULL);
@@ -166,14 +166,12 @@ int main(int argc, char *argv[]) {
       ep->timeout = strtonum(optarg, INT32_MIN, INT32_MAX, NULL);
       if (errno)
         exit(errno);
-      break;
-    case 'I':
-      if (strtonum(optarg, 0, 1, NULL))
+      if (ep->timeout < 0)
+        ep->timeout = INT32_MAX;
+      if (ep->timeout == 0)
         ep->opt |= EPCAP_OPT_IMMEDIATE;
       else
         ep->opt &= ~EPCAP_OPT_IMMEDIATE;
-      if (errno)
-        exit(errno);
       break;
     case 'u':
       ep->user = strdup(optarg);
@@ -643,7 +641,6 @@ static void usage(EPCAP_STATE *ep) {
 #endif
       "              -s <length>      packet capture length\n"
       "              -t <millisecond> capture timeout\n"
-      "              -I               enable immediate mode\n"
       "              -e <key>=<val>   set an environment variable\n"
       "              -v               verbose mode\n"
       "              -X               enable sending packets\n"

--- a/src/epcap.erl
+++ b/src/epcap.erl
@@ -186,13 +186,13 @@ handle_info(Info,
 %%--------------------------------------------------------------------
 -type arg_num() :: string() | non_neg_integer().
 
--type options() :: [inject | monitor | promiscuous | verbose | immediate |
+-type options() :: [inject | monitor | promiscuous | verbose |
                     {buffer, arg_num()} | {chroot, string()} | {cluster_id, arg_num()} |
                     {direction, in | out | inout} | {env, string()} | {exec, string()} |
                     {file, string()} | {filter, string()} | {group, string()} |
                     {interface, string()} | {progname, string()} | {snaplen, arg_num()} |
-                    {time_unit, time_unit()} | {timeout, arg_num()} | {user, string()} |
-                    {verbose, arg_num()}].
+                    {time_unit, time_unit()} | {timeout, arg_num() | infinity | immediate} |
+                    {user, string()} | {verbose, arg_num()}].
 
 -spec setopts(options(), options()) -> options().
 
@@ -230,9 +230,9 @@ optarg(monitor) -> switch("M");
 optarg(promiscuous) -> switch("P");
 optarg({snaplen, Arg}) -> switch("s", maybe_string(Arg));
 optarg({time_unit, Arg}) -> switch("T", time_unit(Arg));
+optarg({timeout, immediate}) -> switch("t", "0");
+optarg({timeout, infinity}) -> switch("t", "-1");
 optarg({timeout, Arg}) -> switch("t", maybe_string(Arg));
-optarg(immediate) -> switch("I", "1");
-optarg({immediate, false}) -> switch("I", "0");
 optarg({user, Arg}) -> switch("u", Arg);
 optarg(verbose) -> switch("v");
 optarg({verbose, 0}) -> "";

--- a/test/epcap_SUITE.erl
+++ b/test/epcap_SUITE.erl
@@ -133,14 +133,16 @@ end_per_testcase(_Test, Config) ->
 getopts(_Config) ->
     [Sudo, "-n", Progname, "-b", "1024", "-d", "/tmp/", "-e",
      "PCAP_PF_RING_CLUSTER_ID=0", "-g", "nobody", "-i", "eth0", "-M", "-P", "-s",
-     "256", "-T", "1", "-u", "nobody", "-v", "-vvv", "-X", "-Q", "inout", "-t", "0",
-     "-I", "1", "-I", "0", "-e", "FOO=bar", "tcp and port 80"] =
+     "256", "-T", "1", "-u", "nobody", "-v", "-vvv", "-X", "-Q", "inout",
+     "-t", "1", "-t", "-1", "-t", "0",
+     "-e", "FOO=bar", "tcp and port 80"] =
         epcap:getopts([{buffer, 1024}, {chroot, "/tmp/"}, {cluster_id, 0},
                        {group, "nobody"}, {interface, "eth0"}, monitor, promiscuous, {snaplen, 256},
                        {time_unit, microsecond}, {time_out, 60}, {user, "nobody"}, verbose,
                        {verbose, 3}, {verbose, 0}, inject, {direction, inout},
-                       {filter, "tcp and port 80"}, {timeout, 0}, {exec, "sudo -n"},
-                       immediate, {immediate, false},
+                       {filter, "tcp and port 80"},
+                       {timeout, 1}, {timeout, infinity}, {timeout, immediate},
+                       {exec, "sudo -n"},
                        {env, "FOO=bar"}]),
     "sudo" = filename:basename(Sudo),
     "epcap" = filename:basename(Progname),


### PR DESCRIPTION
Currently the 'timeout' and 'immediate' options map to pcap_set_timeout
and pcap_set_immediate_mode, where the latter is activated by default.
Thus the timeout is only honoured when 'immediate' is set to false. In
addition the timeout value 0 has an undefined behaviour according to
[pcap_set_timeout(3PCAP)](https://www.tcpdump.org/manpages/pcap_set_timeout.3pcap.html)  and may cause infinity waiting according to
[pcap(3PCAP)](https://www.tcpdump.org/manpages/pcap.3pcap.html).

See also #29 for a related discussion.

Erlang/OTP timeouts are generally given by either the number of milliseconds
to wait, 'infinity' to disable the timeout or 0 (if permitted) to
do something immediately.

Change the behaviour of the 'timeout' parameter to be similar to be
compatible with the Erlang/OTP way:

- N with N>0:   Set this timeout (in msecs) with pcap_set_timeout and
                disable immediate mode. The exact behaviour is platform
                dependent.
- 'infinity':   Wait until the pcap buffer is filled
- 'immediate':  Enforce immediate mode
- 0:            Deliver packets without delay (equivalent to immediate
                mode)

Remove the stand-alone 'immediate' option.

Change the epcap command line option -t to use 0 for immediate mode
and <0 to represent 'infinity'.

Note that this will change the behaviour for {timeout, 0} on Linux
when using libpcap >1.5.0.

Note also that according to pcap(3PCAP) the support of "packet buffer
timeouts" may not be provided by all platforms.

