### PR TITLE
Fix strtonum error handling

### DIFF
--- a/c_src/epcap.c
+++ b/c_src/epcap.c
@@ -74,6 +74,7 @@ int main(int argc, char *argv[]) {
   EPCAP_STATE *ep = NULL;
   int ch = 0;
   int fd = 0;
+  const char *errstr = NULL;
 
 #ifndef HAVE_SETPROCTITLE
   spt_init(argc, argv);
@@ -91,8 +92,8 @@ int main(int argc, char *argv[]) {
   while ((ch = getopt(argc, argv, "b:d:e:f:g:hi:MPs:T:t:I:u:Q:vX")) != -1) {
     switch (ch) {
     case 'b':
-      ep->bufsz = strtonum(optarg, INT32_MIN, INT32_MAX, NULL);
-      if (errno)
+      ep->bufsz = strtonum(optarg, INT32_MIN, INT32_MAX, &errstr);
+      if (errstr)
         exit(errno);
       break;
     case 'd': /* chroot directory */
@@ -153,26 +154,26 @@ int main(int argc, char *argv[]) {
       ep->opt |= EPCAP_OPT_PROMISC;
       break;
     case 's':
-      ep->snaplen = strtonum(optarg, INT32_MIN, INT32_MAX, NULL);
-      if (errno)
+      ep->snaplen = strtonum(optarg, INT32_MIN, INT32_MAX, &errstr);
+      if (errstr)
         exit(errno);
       break;
     case 'T':
-      ep->time_unit = strtonum(optarg, 0, 1, NULL);
-      if (errno)
+      ep->time_unit = strtonum(optarg, 0, 1, &errstr);
+      if (errstr)
         exit(errno);
       break;
     case 't':
-      ep->timeout = strtonum(optarg, INT32_MIN, INT32_MAX, NULL);
-      if (errno)
+      ep->timeout = strtonum(optarg, INT32_MIN, INT32_MAX, &errstr);
+      if (errstr)
         exit(errno);
       break;
     case 'I':
-      if (strtonum(optarg, 0, 1, NULL))
+      if (strtonum(optarg, 0, 1, &errstr))
         ep->opt |= EPCAP_OPT_IMMEDIATE;
       else
         ep->opt &= ~EPCAP_OPT_IMMEDIATE;
-      if (errno)
+      if (errstr)
         exit(errno);
       break;
     case 'u':

--- a/c_src/epcap.c
+++ b/c_src/epcap.c
@@ -93,8 +93,10 @@ int main(int argc, char *argv[]) {
     switch (ch) {
     case 'b':
       ep->bufsz = strtonum(optarg, INT32_MIN, INT32_MAX, &errstr);
-      if (errstr)
+      if (errstr) {
+        VERBOSE(0, "%s, invalid buffer size (-b) value: %s\n", __progname, errstr);
         exit(errno);
+      }
       break;
     case 'd': /* chroot directory */
       ep->chroot = strdup(optarg);
@@ -155,26 +157,34 @@ int main(int argc, char *argv[]) {
       break;
     case 's':
       ep->snaplen = strtonum(optarg, INT32_MIN, INT32_MAX, &errstr);
-      if (errstr)
+      if (errstr) {
+        VERBOSE(0, "%s, invalid snap length (-s) value: %s\n", __progname, errstr);
         exit(errno);
+      }
       break;
     case 'T':
       ep->time_unit = strtonum(optarg, 0, 1, &errstr);
-      if (errstr)
+      if (errstr) {
+        VERBOSE(0, "%s, invalid time unit (-T) value: %s\n", __progname, errstr);
         exit(errno);
+      }
       break;
     case 't':
       ep->timeout = strtonum(optarg, INT32_MIN, INT32_MAX, &errstr);
-      if (errstr)
+      if (errstr) {
+        VERBOSE(0, "%s, invalid timeout (-t) value: %s\n", __progname, errstr);
         exit(errno);
+      }
       break;
     case 'I':
       if (strtonum(optarg, 0, 1, &errstr))
         ep->opt |= EPCAP_OPT_IMMEDIATE;
       else
         ep->opt &= ~EPCAP_OPT_IMMEDIATE;
-      if (errstr)
+      if (errstr) {
+        VERBOSE(0, "%s, invalid immediate mode (-I) value: %s\n", __progname, errstr);
         exit(errno);
+      }
       break;
     case 'u':
       ep->user = strdup(optarg);


### PR DESCRIPTION
The epcap command failed on a single FreeBSD12 installation (Jenkins build host) with no obvious indication about the error. It turned out that the errno variable was non-zero initially causing the first numeric option to report an error.
This PR changes the error check to use the errstrp parameter to decide whether to abort. It also adds calls to display error messages in these cases.